### PR TITLE
Reconnect gracefully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: node_js
 node_js:
   - "10.3"
 before_install:
- - npm i -g npm@6.4.0
+  - npm i -g npm@6.4.0
 cache:
- directories:
-   - "node_modules"
+  directories:
+    - "node_modules"
+notifications:
+  slack:
+    pointapi:Sjvqcwm25jFhXxEdZirCDqRk

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.0.11",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Javascript SDK for Point API",
   "repository": "github:PointMail/js-sdk",
   "homepage": "https://docs.pointapi.com",

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,6 +89,10 @@ export default class PointApi {
       this.reconnectCount = 0;
     });
     this.socket.on("disconnect", (reason: any) => {
+      // If client was the one that disconnected,
+      // don't reconnect automatically
+      if (reason === "io client disconnect") return;
+
       // Try to reconnect maxReconnect times using exponentially
       // growing delays starting from 100ms
       if (this.reconnectCount < this.maxReconnects) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,6 +51,12 @@ export default class PointApi {
   /** @private SocketIO instance used to interact with Point API */
   private socket: SocketIOClient.Socket;
 
+  /** @private Reconnect counter  */
+  private reconnectCount: number = 0;
+
+  /** @private Max reconnect attempts  */
+  private readonly maxReconnects: number = 10;
+
   /**
    * @param  emailAddress Email address of Point user
    * @param  authCode Auth code of Point client
@@ -60,7 +66,6 @@ export default class PointApi {
     authCode: string,
     searchType = "standard",
     apiUrl = "https://v1.pointapi.com"
-
   ) {
     this.emailAddress = emailAddress;
     this.authCode = authCode;
@@ -80,8 +85,19 @@ export default class PointApi {
         }
       }
     });
+    this.socket.on("connect", () => {
+      this.reconnectCount = 0;
+    });
     this.socket.on("disconnect", (reason: any) => {
-      this.socket.connect();
+      // Try to reconnect maxReconnect times using exponentially
+      // growing delays starting from 100ms
+      if (this.reconnectCount < this.maxReconnects) {
+        const delay = 100 * Math.pow(2, this.reconnectCount);
+        this.reconnectCount++;
+        setTimeout(() => {
+          this.socket.connect();
+        }, delay);
+      }
     });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,6 +106,13 @@ export default class PointApi {
   }
 
   /**
+   * Disconnects from the Point API manually
+   */
+  public disconnect(): void {
+    this.socket.disconnect();
+  }
+
+  /**
    *  Query PointApi with seed text to get predicted suggestions
    * @param seedText The text to base suggestion predictions off of
    * @returns A list of the predicted suggestion objects


### PR DESCRIPTION
Disconnect event shouldn't reconnect unconditionally.
- If the reason is `io client disconnect` - meaning it was disconnected on purpose by client, don't try to reconnect at all.
- If the reason was different - try to reconnect more gracefully.

Add `disconnect()` method to public api of `PointApi`.