### PR TITLE
Fix jwt refresh after sleep

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,8 +31,6 @@ export default class PointApi extends PointApiBase {
     this.apiKey = apiKey;
 
     this.jwt = null;
-
-    this.refreshJwtToken();
   }
 
   public setCredentials(emailAddress: string, apiKey: string) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ export default class PointApi extends PointApiBase {
 
     this.jwt = null;
     if (this.jwtRenewTimeoutId) {
-      clearTimeout(this.jwtRenewTimeoutId);
+      clearInterval(this.jwtRenewTimeoutId);
     }
 
     this.refreshJwtToken();
@@ -96,11 +96,12 @@ export default class PointApi extends PointApiBase {
 
     if (autoRenew) {
       if (this.jwtRenewTimeoutId) {
-        clearTimeout(this.jwtRenewTimeoutId);
+        clearInterval(this.jwtRenewTimeoutId);
       }
 
       // Renew JWT 5 seconds before it's exipration
-      this.jwtRenewTimeoutId = setTimeout(async () => {
+      this.jwtRenewTimeoutId = setInterval(async () => {
+        clearInterval(this.jwtRenewTimeoutId);
         await this.refreshJwtToken();
       }, response.expiresAt - Date.now() - 5000);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ export default class PointApi extends PointApiBase {
 
     this.jwt = null;
     if (this.jwtRenewTimeoutId) {
-      clearInterval(this.jwtRenewTimeoutId);
+      clearTimeout(this.jwtRenewTimeoutId);
     }
 
     this.refreshJwtToken();
@@ -101,12 +101,11 @@ export default class PointApi extends PointApiBase {
 
         if (autoRenew) {
           if (this.jwtRenewTimeoutId) {
-            clearInterval(this.jwtRenewTimeoutId);
+            clearTimeout(this.jwtRenewTimeoutId);
           }
 
           // Renew JWT 5 seconds before it's exipration
-          this.jwtRenewTimeoutId = setInterval(async () => {
-            clearInterval(this.jwtRenewTimeoutId);
+          this.jwtRenewTimeoutId = setTimeout(async () => {
             await this.refreshJwtToken();
           }, responseJson.expiresAt - Date.now() - 5000);
         }


### PR DESCRIPTION
I've discovered one reason why our JWT refreshing was failing after waking up computer with the gmail opened. It was happening when JWT expired in the meantime and first `/auth` request was failing due to **Network Changed** errors (e.g. reconnecting to WiFi).

My fix was to change `setTimeout ` to `setInterval` (timeouts weren't fired after waking up the computer) and implementing error handling for `refreshJwtToken()` with 10 retries with delays.

Jira: https://easyemail.atlassian.net/browse/BACKEND-391