### PR TITLE
Track payment interactions (events)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ typings/
 
 # IntelliJ IDEA
 .idea/
+
+# MacOS
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Javascript SDK for Point API",
   "repository": "github:PointMail/js-sdk",
   "homepage": "https://docs.pointapi.com",

--- a/src/ApiModules/events.ts
+++ b/src/ApiModules/events.ts
@@ -3,10 +3,16 @@ export default class EventsApiModule {
   /** Point API URL */
   public readonly apiUrl: string;
 
+  private readonly emailAddress: string = "";
+
   private readonly url: string = "/events";
 
-  constructor(apiUrl: string = "https://v1.pointapi.com") {
+  constructor(apiUrl: string = "https://v1.pointapi.com", emailAddress?: string) {
     this.apiUrl = apiUrl;
+
+    if (emailAddress) {
+      this.emailAddress = emailAddress;
+    }
   }
 
   public async scribeInstalled(id: string) {
@@ -17,10 +23,31 @@ export default class EventsApiModule {
     this.storeEvent("scribeUninstalled", { id });
   }
 
-  private async storeEvent(type: string, data?: object) {
+  public async paymentInfoFreeTrialShown(id: string) {
+    this.storeEvent("paymentInfoFreeTrialShown", { id });
+  }
+
+  public async paymentFailure(id: string) {
+    this.storeEvent("paymentFailure", { id });
+  }
+
+  public async paymentOpened(id: string) {
+    this.storeEvent("paymentOpened", { id });
+  }
+
+  public async paymentSuccess(id: string) {
+    this.storeEvent("paymentSuccess", { id });
+  }
+
+  private async storeEvent(type: string, data: object) {
     const headers = {
       "Content-Type": "application/json"
     };
+
+    if (this.emailAddress) {
+      data["emailAddress"] = this.emailAddress;
+    }
+
     this.fetch("POST", { type, data }, headers);
   }
 

--- a/src/ApiModules/events.ts
+++ b/src/ApiModules/events.ts
@@ -16,42 +16,44 @@ export default class EventsApiModule {
   }
 
   public async scribeInstalled(id: string) {
-    this.storeEvent("scribeInstalled", { id });
+    this.storeEvent("scribeInstalled", id);
   }
 
   public async scribeUninstalled(id: string) {
-    this.storeEvent("scribeUninstalled", { id });
+    this.storeEvent("scribeUninstalled", id);
   }
 
   public async paymentInfoFreeTrialShown(id: string) {
-    this.storeEvent("paymentInfoFreeTrialShown", { id });
+    this.storeEvent("paymentInfoFreeTrialShown", id);
   }
 
   public async paymentFailure(id: string) {
-    this.storeEvent("paymentFailure", { id });
+    this.storeEvent("paymentFailure", id);
   }
 
   public async paymentOpened(id: string) {
-    this.storeEvent("paymentOpened", { id });
+    this.storeEvent("paymentOpened", id);
   }
 
   public async paymentSuccess(id: string) {
-    this.storeEvent("paymentSuccess", { id });
+    this.storeEvent("paymentSuccess", id);
   }
 
-  private async storeEvent(type: string, data: object) {
+  private async storeEvent(type: string, trackingId: string, data?: object) {
     const headers = {
       "Content-Type": "application/json"
     };
 
+    const payload = { type, trackingId, data };
+
     if (this.emailAddress) {
-      data["emailAddress"] = this.emailAddress;
+      payload["emailAddress"] = this.emailAddress;
     }
 
-    this.fetch("POST", { type, data }, headers);
+    this.fetch("POST", payload, headers);
   }
 
-  /** Make unauthenticated request to events api */
+  /** Make unauthenticated request to Events API Resource */
   private async fetch(
     method: string,
     data?: object,


### PR DESCRIPTION
I'm storing these interactions as events (non authorized interactions even though we should be able to authorize the requests - the user already has the API Key). I tried using `interactions` (authorized) but it would require much bigger changes to the account-management and how `PointAPI` is initialized and passed around.
Anyway I'm storing `trackingId` & `emailAddress` so we can tie both values here. 