### PR TITLE
Update /customSuggestions endpoint API

### DIFF
--- a/src/ApiModules/customSuggestions.ts
+++ b/src/ApiModules/customSuggestions.ts
@@ -1,7 +1,7 @@
 import PointApiBase from "../pointApiBase";
 
 /** Result of a GET request to api */
-interface GetResponse {
+export interface GetResponse {
   blacklistEnabled: boolean;
   blacklist: Blacklist[];
   suggestionsEnabled: boolean;

--- a/src/ApiModules/customSuggestions.ts
+++ b/src/ApiModules/customSuggestions.ts
@@ -2,13 +2,23 @@ import PointApiBase from "../pointApiBase";
 
 /** Result of a GET request to api */
 interface GetResponse {
+  blacklistEnabled: boolean;
+  blacklist: Blacklist[];
+  suggestionsEnabled: boolean;
   suggestions: Suggestion[];
+  hotkeysEnabled: boolean;
   hotkeys: Hotkey[];
 }
 
 /** Result containing just a status field */
 interface StatusResponse {
   status: string;
+}
+
+/** Blacklisted suggestion object */
+export interface Blacklist {
+  id: string;
+  text: string;
 }
 
 /** Custom suggestion object. Adds custom suggestion text to the dropdown */

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,9 @@ import AutocompleteSession, {
 } from "./ApiModules/autocompleteSession";
 
 import CustomSuggestionsApiModule, {
-  Suggestion,
-  Hotkey
+  Blacklist,
+  Hotkey,
+  Suggestion
 } from "./ApiModules/customSuggestions";
 
 import Events from "./ApiModules/events";
@@ -39,7 +40,7 @@ export {
   AutocompleteResponse,
   ReplyResponse
 };
-export { CustomSuggestionsApiModule, Suggestion, Hotkey };
+export { CustomSuggestionsApiModule, Blacklist, Hotkey, Suggestion };
 export { Events };
 export { InteractionsApiModule, StatusResponse };
 export * from "./main";

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import AutocompleteSession, {
 
 import CustomSuggestionsApiModule, {
   Blacklist,
+  GetResponse as CustomSuggestionsGetResponse,
   Hotkey,
   Suggestion
 } from "./ApiModules/customSuggestions";
@@ -40,7 +41,7 @@ export {
   AutocompleteResponse,
   ReplyResponse
 };
-export { CustomSuggestionsApiModule, Blacklist, Hotkey, Suggestion };
+export { CustomSuggestionsApiModule, Blacklist, CustomSuggestionsGetResponse, Hotkey, Suggestion };
 export { Events };
 export { InteractionsApiModule, StatusResponse };
 export * from "./main";


### PR DESCRIPTION
Custom suggestions API was extended with new return data format. It allows to check if the user is allowed to add custom suggestions, hotkeys & blacklisting. These options are only disabled before user's profile is created. After successful initialization all of the options should be enabled.

Another change was to add throwing an `Error` when `/auth` endpoint fails to respond with JWT. This way clients can handle errors such as `HTTP 401 Unauthorized`.