### PR TITLE
BACKEND-661 Continuous deployment to npmjs.com using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,39 @@
 language: node_js
 node_js:
-  - "10.3"
-before_install:
-  - npm i -g npm@6.4.0
-cache:
-  directories:
-    - "node_modules"
+- '10.3'
+cache: npm
 notifications:
-  slack:
-    pointapi:Sjvqcwm25jFhXxEdZirCDqRk
+  slack: pointapi:Sjvqcwm25jFhXxEdZirCDqRk
+before_install:
+- npm i -g npm@6.9.0
+install:
+- npm ci
+jobs:
+  include:
+  - stage: test
+    script:
+    - npm test
+    - npm run build
+  - stage: release  # npm release
+    if: branch IN (master, dev)
+    script: 
+    - echo "Deploying to npm.."
+    - npm run build
+    - bash ./scripts/release.sh  # Bump version
+    deploy:
+    - provider: npm
+      email: $NPMJS_EMAIL
+      api_key: $NPMJS_ACCESS_TOKEN
+      tag: latest
+      skip_cleanup: true
+      on:
+        repo: PointMail/js-sdk
+        branch: master
+    - provider: npm
+      email: $NPMJS_EMAIL
+      api_key: $NPMJS_ACCESS_TOKEN
+      tag: dev
+      skip_cleanup: true
+      on:
+        repo: PointMail/js-sdk
+        branch: dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "description": "Javascript SDK for Point API",
   "repository": "github:PointMail/js-sdk",
   "homepage": "https://docs.pointapi.com",
@@ -23,6 +23,7 @@
     "test": "jest",
     "build": "tsc && npm run build-umd",
     "build-umd": "parcel build src/index-umd.ts --global PointApi --out-file index.js",
+    "release": "npm version patch -m \"Bumping to %s\" && git push origin master --tags",
     "gen-docs": "typedoc --out docs src --theme markdown",
     "publish": "npm run build-umd && npm run build && npm publish --access public && npm run push-to-site",
     "push-to-site": "aws s3 cp ./dist/index.js s3://point-api-website/api.js"
@@ -66,5 +67,8 @@
   },
   "browserslist": [
     "last 1 Chrome version"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,44 @@
+#/bin/bash
+
+BRANCH_NAME=${TRAVIS_BRANCH:=`git rev-parse --symbolic-full-name --abbrev-ref HEAD`}
+
+setup_git() {
+  git config --global user.email "travis@pointapi.com"
+  git config --global user.name "Travis CI"
+}
+
+release_master() {
+    echo "Releasing master"
+    
+    setup_git
+
+    echo "Bumping npm version.."
+    npm version patch -m "Bumping to %s [skip ci]"
+
+    echo "Pushing to git.."
+    git remote show origin
+    git remote rm origin
+    git remote add origin https://${GH_TOKEN}@github.com/PointMail/js-sdk.git > /dev/null 2>&1
+    git push origin HEAD:${BRANCH_NAME}
+    git push --tags
+}
+
+release_dev() {
+    echo "Releasing dev"
+
+    COMMIT_SHA=${TRAVIS_COMMIT:=`git log --pretty=format:'%h' -n 1`}
+    COMMIT_SHA=${COMMIT_SHA::7}
+    DEV_VERSION=0.0.0-${BRANCH_NAME}.${COMMIT_SHA}
+
+    echo "Bumping npm version to ${DEV_VERSION}.."
+    npm version ${DEV_VERSION} -m "Bumping to %s"
+}
+
+
+if [ ${BRANCH_NAME} = "master" ]; then
+    release_master
+else
+    release_dev
+fi
+
+echo "Done!"


### PR DESCRIPTION
Deployment uses my npmjs.com API Key and could be probably changed (they seem to have to be attached to a user).

Pushing back bump commit from travis also uses my [Personal Access Token](https://github.com/settings/tokens) - it should be changed.

Deployments from `master` are producing a git tag & new version patch release and are tagged 'latest' in [npmjs.com](https://www.npmjs.com/package/@point-api/js-sdk). Master deployments are creating a version bump commit automatically. All versions will also be visible on [GitHub releases page](https://github.com/PointMail/js-sdk/releases) because they'll have Git tag (e.g. v1.1.22)

Deployments from `dev` are also deployed to npm.js.com but they are released under version `0.0.0-dev-COMMIT_SHA` and tagged 'dev'. Development deployments are not creating any version bump commits.


~~After merging all the stuff into master and to make a release (git tag & deploy to npmjs) you need to locally run a single command on `master` branch. The command is `npm run release`. This will automatically bump the version numbers, commit and push it along with a version tag. The only problem is that this is a direct push to `master` which we may have disabled (and for a good reason)~~
