### PR TITLE
BACKEND-657 Fix membership expired errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Javascript SDK for Point API",
   "repository": "github:PointMail/js-sdk",
   "homepage": "https://docs.pointapi.com",

--- a/src/ApiModules/account.ts
+++ b/src/ApiModules/account.ts
@@ -45,6 +45,6 @@ export default class AccountApiModule {
     const headers = {
       "Content-Type": "application/json"
     };
-    return this.api.authFetch(method, this.url, data, headers);
+    return this.api.authFetch(method, this.url, false, data, headers);
   }
 }

--- a/src/ApiModules/autocompleteSession.ts
+++ b/src/ApiModules/autocompleteSession.ts
@@ -82,6 +82,12 @@ export default class AutocompleteSession {
   public async reconnect(): Promise<void> {
     this.disconnect();
 
+    // Check if the account is active
+    if (!await this.authManager.isActive()) {
+      throw new Error("Trying to init autocomplete session with "
+        + "an inactive account");
+    }
+
     this.authManager.onJwtChange(this.onJwtChange);
 
     const jwt = await this.authManager.getJwt();
@@ -152,7 +158,7 @@ export default class AutocompleteSession {
     currentContext?: string
   ): Promise<AutocompleteResponse | null> {
     return new Promise((resolve, reject) => {
-      if (this.socket.disconnected) {
+      if (!this.socket || this.socket.disconnected) {
         reject("Socket is disconnected");
       }
       this.socket.emit(
@@ -179,7 +185,7 @@ export default class AutocompleteSession {
    */
   public hotkey(trigger: string): Promise<AutocompleteResponse | null> {
     return new Promise((resolve, reject) => {
-      if (this.socket.disconnected) {
+      if (!this.socket || this.socket.disconnected) {
         reject("Socket is disconnected");
       }
       this.socket.emit(
@@ -250,7 +256,7 @@ export default class AutocompleteSession {
     contextType: ContextType = "text"
   ): Promise<ReplyResponse | null> {
     return new Promise((resolve, reject) => {
-      if (this.socket.disconnected) {
+      if (!this.socket || this.socket.disconnected) {
         reject("Socket is disconnected");
       }
       this.socket.emit(

--- a/src/ApiModules/customSuggestions.ts
+++ b/src/ApiModules/customSuggestions.ts
@@ -56,13 +56,13 @@ export default class CustomSuggestionsApiModule {
   }
 
   public async edit(
-    type:string,
+    type: string,
     oldText: string,
     newText: string,
     oldTrigger?: string,
     newTrigger?: string
   ): Promise<StatusResponse> {
-    return this.authFetch("PUT", {type, oldText, newText, oldTrigger, newTrigger})
+    return this.authFetch("PUT", { type, oldText, newText, oldTrigger, newTrigger })
   }
 
   /** Add a custom suggestion or hotkey */
@@ -76,6 +76,6 @@ export default class CustomSuggestionsApiModule {
 
   /** Make authenticated request to custom suggestions api */
   private async authFetch(method: string, data?: object) {
-    return (await this.api.authFetch(method, this.url, data)).json();
+    return (await this.api.authFetch(method, this.url, true, data)).json();
   }
 }

--- a/src/ApiModules/interactions.ts
+++ b/src/ApiModules/interactions.ts
@@ -64,6 +64,6 @@ export default class InteractionsApiModule {
     const headers = {
       "Content-Type": "application/json"
     };
-    await this.api.authFetch(method, this.url, data, headers);
+    await this.api.authFetch(method, this.url, false, data, headers);
   }
 }

--- a/src/authManager.ts
+++ b/src/authManager.ts
@@ -102,7 +102,7 @@ export default class AuthManager {
 
     try {
       const response = await fetch(
-        `${apiUrl}/auth?emailAddress=${emailAddress}`,
+        `${apiUrl}/auth?init&emailAddress=${emailAddress}`,
         {
           headers: {
             Authorization: `Bearer ${apiKey}`

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,18 +76,39 @@ export default class PointApi extends PointApiBase {
     return session;
   }
 
+  /**
+   * Fetches the URL from the server endpoint.
+   * 
+   * Param @mustBeActive should be set to @true if the enpoint requires 
+   * an active membership. The method will reject if this flag is @true
+   * and the membership is inactive.
+   * 
+   * @param method HTTP method type
+   * @param url Endpoint URL (e.g. /auth or /account)
+   * @param mustBeActive Whether to check membership
+   * @param data Payload for the body of the request (e.g. in POST)
+   * @param headers Headers to add to the request
+   */
   public async authFetch(
     method: string,
     url: string,
+    mustBeActive: boolean,
     data?: object,
-    headers?: object
+    headers?: object,
   ) {
     const jwt = await this.authManager.getJwt();
+    
+    // Check if the membership is active if `mustBeActive` is true
+    if (mustBeActive && !(await this.authManager.isActive())) {
+      throw new Error("Trying to fetch active users only endpoint with "
+        + "an inactive account");
+    }
 
     const authHeaders = {
       Authorization: `Bearer ${jwt}`,
       ...headers
     };
-    return super.authFetch(method, url, data, authHeaders);
+
+    return super.authFetch(method, url, mustBeActive, data, authHeaders);
   }
 }

--- a/src/pointApiBase.ts
+++ b/src/pointApiBase.ts
@@ -38,14 +38,15 @@ export default class PointApiBase {
 
   public async getAccountInfo(): Promise<Account> {
     // getAccountInfo() is deprecated. Use account.get()
-    return (await this.authFetch("GET", "/account")).json();
+    return (await this.authFetch("GET", "/account", false)).json();
   }
 
   public async authFetch(
     method: string,
     url: string,
+    mustBeActive: boolean,
     data?: object,
-    headers?: Record<string, string>
+    headers?: Record<string, string>,
   ) {
     return this.fetch(method, url, data, headers);
   }


### PR DESCRIPTION
- add `mustBeActive` parameter to `authFetch()` method to verify if
  the membership is active before firing a request.
- check if the membership is active in `AutocompleteSession.reconnect()`
  method.
- add '?init' param to /auth request (to initialize session right away during auth)