### PR TITLE
Fix bug causing account switching to break

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "Javascript SDK for Point API",
   "repository": "github:PointMail/js-sdk",
   "homepage": "https://docs.pointapi.com",

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ export default class PointApi extends PointApiBase {
   }
 
   public setCredentials(emailAddress: string, apiKey: string) {
+    this.emailAddress = emailAddress;
     this.authManager.setCredentials(emailAddress, apiKey);
   }
 


### PR DESCRIPTION
PointApi.setCredentials() didn't update the email address that is used in API requests causing JWT auth errors after changing credentials.