### PR TITLE
Fix creating custom snippets in PointApiDemo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "description": "Javascript SDK for Point API",
   "repository": "github:PointMail/js-sdk",
   "homepage": "https://docs.pointapi.com",

--- a/src/Demo/suggestionsStore.ts
+++ b/src/Demo/suggestionsStore.ts
@@ -32,10 +32,10 @@ export default class SuggestionsStore {
   public addHotkey(trigger: string, text: string) {
     this.hotkeys.push({
       suggestion: trigger,
-      type: '',
-      baseClass: '',
+      type: 'custom',
+      baseClass: 'hotkey',
       expandedSuggestion: text,
-      userAdded: false
+      userAdded: true
     });
   }
 }


### PR DESCRIPTION
Before this fix step 9 of the tutorial was breaking - snippet was not inserted correctly.