### PR TITLE
BACKEND-1079 tutorial persist saves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.1.33",
+  "version": "1.1.34",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@point-api/js-sdk",
-  "version": "1.1.33",
+  "version": "1.1.34",
   "description": "Javascript SDK for Point API",
   "repository": "github:PointMail/js-sdk",
   "homepage": "https://docs.pointapi.com",

--- a/src/Demo/pointApiDemo.ts
+++ b/src/Demo/pointApiDemo.ts
@@ -1,6 +1,6 @@
 import AccountApiModule from "../ApiModules/account";
 import { AutocompleteSession } from "../ApiModules/autocompleteSession";
-import CustomSuggestionsApiModule from "../ApiModules/customSuggestions";
+import CustomSuggestionsApiModule, { GetResponse } from "../ApiModules/customSuggestions";
 import InteractionsApiModule from "../ApiModules/interactions";
 import { AuthManager } from "../authManager";
 import { PointApi } from "../main";
@@ -23,9 +23,7 @@ export default class PointApiDemo implements PointApi {
 
   private authManager: AuthManager;
 
-  constructor(
-    emailAddress: string,
-  ) {
+  constructor(emailAddress: string) {
     this.emailAddress = emailAddress;
     this.apiUrl = "demo";
 
@@ -80,5 +78,15 @@ export default class PointApiDemo implements PointApi {
   ) {
     const response = this.server.httpRequest(method, url, data, headers);
     return Promise.resolve(response);
+  }
+
+  public setCustomSuggestionsData(customSuggestions: GetResponse) {
+    for (const h of customSuggestions.hotkeys) {      
+      this.server.addHotkey(h.text, h.trigger, h.labels);
+    }
+
+    for (const s of customSuggestions.suggestions) {
+      this.server.addCustomSuggestion(s.text);
+    }
   }
 }

--- a/src/Demo/suggestionsStore.ts
+++ b/src/Demo/suggestionsStore.ts
@@ -1,18 +1,22 @@
 import { SuggestionMeta } from "../ApiModules/autocompleteSession";
 
+interface SuggestionMetaWithLabels extends SuggestionMeta {
+  labels: string[];
+}
+
 const INITIAL_SUGGESTIONS: SuggestionMeta[] = [
   { suggestion: 'Nice to meet you!', type: 'default', baseClass: 'suggestion', expandedSuggestion: '', userAdded: false },
   { suggestion: 'Nice to hear from you.', type: 'default', baseClass: 'suggestion', expandedSuggestion: '', userAdded: false },
   { suggestion: 'What do you think?', type: 'default', baseClass: 'suggestion', expandedSuggestion: '', userAdded: false }
 ];
 
-const INITIAL_HOTKEYS: SuggestionMeta[] = [
-  { suggestion: 'about', type: 'custom', baseClass: 'hotkey', expandedSuggestion: "Point uses AI to predict what you want to say and writes it in your own words. With our suggestions, you will communicate quickly, intelligently, and effortlessly.", userAdded: false },
+const INITIAL_HOTKEYS: SuggestionMetaWithLabels[] = [
+  { suggestion: 'about', labels: ['tutorial'], type: 'custom', baseClass: 'hotkey', expandedSuggestion: "Point uses AI to predict what you want to say and writes it in your own words. With our suggestions, you will communicate quickly, intelligently, and effortlessly.", userAdded: false },
 ];
 
 export default class SuggestionsStore {
   public readonly suggestions: SuggestionMeta[];
-  public readonly hotkeys: SuggestionMeta[];
+  public readonly hotkeys: SuggestionMetaWithLabels[];
 
   public constructor() {
     this.suggestions = INITIAL_SUGGESTIONS.slice();
@@ -20,7 +24,7 @@ export default class SuggestionsStore {
   }
 
   public addCustomSuggestion(suggestion: string) {
-    this.suggestions.push({
+    this.suggestions.unshift({
       suggestion,
       type: 'custom',
       baseClass: 'suggestion',
@@ -29,13 +33,22 @@ export default class SuggestionsStore {
     });
   }
 
-  public addHotkey(trigger: string, text: string) {
-    this.hotkeys.push({
+  public addHotkey(trigger: string, text: string, labels: string[]) {
+    this.hotkeys.unshift({
       suggestion: trigger,
       type: 'custom',
       baseClass: 'hotkey',
       expandedSuggestion: text,
-      userAdded: true
+      userAdded: true,
+      labels,
     });
+  }
+
+  public customSuggestionExists(suggestion: string) {
+    return this.suggestions.filter(s => s.suggestion === suggestion).length > 0;
+  }
+
+  public hotkeyTriggerExists(trigger: string) {
+    return this.hotkeys.filter(h => h.suggestion === trigger).length > 0;
   }
 }


### PR DESCRIPTION
## Description

- allow to preload the PointApiDemo with "real" custom suggestions data: `setCustomSuggestionsData(customSuggestions: GetResponse)`
- check for duplicate triggers & custom suggestions and return an error in PointApiDemo
- error handling for PointApiDemo mock server
- add labels to snippets (hotkeys) in PointApiDemo

### Jira tickets
- https://easyemail.atlassian.net/browse/BACKEND-1079

### Related PRs
- https://github.com/PointMail/account-management/pull/154